### PR TITLE
Fix ComboBox cannot clear value when allowFreeForm

### DIFF
--- a/common/office-ui-fabric-react/combobox_2018-08-02-23-17.json
+++ b/common/office-ui-fabric-react/combobox_2018-08-02-23-17.json
@@ -1,4 +1,4 @@
-
+{
   "changes": [
     {
       "packageName": "office-ui-fabric-react",

--- a/common/office-ui-fabric-react/combobox_2018-08-02-23-17.json
+++ b/common/office-ui-fabric-react/combobox_2018-08-02-23-17.json
@@ -1,0 +1,11 @@
+
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "ComboBox cannot clear value when allowFreeForm enabled. Should trigger onChanged when value is cleared",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "ngyukman@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1014,6 +1014,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           selectedIndices: selectedIndices
         });
       }
+    } else if (allowFreeform && currentPendingValue === '' && onChanged) {
+      // trigger onChanged to clear value
+      onChanged(undefined, undefined, currentPendingValue, submitPendingValueEvent);
     } else if (currentPendingValueValidIndex >= 0) {
       // Since we are not allowing freeform, we must have a matching
       // to be able to update state


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5778
- [x] Include a change request file using `$ npm run change`

#### Description of changes
Right now it is impossible to clear the text in ComboBox since onChanged is skipped when value === ''

#### Focus areas to test

(optional)
